### PR TITLE
Added "line" aligned propagation of stream

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -113,10 +113,6 @@ See https://docs.platformio.org/page/projectconf/build_configurations.html
             last = idx + 1
 
             strip_line = self.strip_ansi(line)
-            # sys.stderr.write(
-            #     "%s: strip_line='%s'\n" % (self.__class__.__name__, strip_line.encode("ascii", "backslashreplace"))
-            # )
-
             m = self.BACKTRACE_PATTERN.match(strip_line)
             if m is None:
                 continue


### PR DESCRIPTION
The additional pre-buffering of input stream with "line aligned" delivery, helps to avoid breaking of escape sequences like "colorization".
It helps for final console output function to not strip "unknown sequences" of non-printable characters.

Now (with my previous commit) colorized output can be used by
```ini
monitor_filters = esp32_exception_decoder
```
i.e. without extra hacks like `monitor_raw = yes` or `monitor_filters = direct, colorize,...`
